### PR TITLE
feat: add filename ejs option

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,8 @@ export function activate(context: vscode.ExtensionContext) {
             let text = editor.document.getText();
             return ejs.render(text, {
                 document : editor.document
+            }, {
+                filename: editor.document.fileName
             });
         }
 


### PR DESCRIPTION
filename option is required for "<%- include('template.ejs') %>" function in ejs templates